### PR TITLE
feat: clear error label automatically

### DIFF
--- a/source/ui/ui.py
+++ b/source/ui/ui.py
@@ -960,8 +960,16 @@ class InputValidation(mainScreen):
             self.label = label
             self.label.config(text = self.message)
 
+            # If the label is the error label, schedule a function to clear it after 5000 milliseconds (5 seconds)
+            if label == self.userInputError_label:
+                self.root.after(5000, lambda: self.clearErrorLabel())
+
         except Exception as e:
             print(f"Error updating {label} with \"{message}\": {e}")
+
+    def clearErrorLabel(self):
+        # Clear the error label text
+        self.userInputError_label.config(text = "")
 
     # This function updates the cmdHistory_label which is the center text box of the program
     # It's meant to be used after a function has been called, to notify the user of

--- a/source/ui/word/word_ui.py
+++ b/source/ui/word/word_ui.py
@@ -44,11 +44,20 @@ class WordWindow(tk.Tk):
     def setLabel(self, label, message):
         try:
             label.config(text = message)
+
+            # If the label is the error label, schedule a function to clear it after 5000 milliseconds (5 seconds)
+            if label == self.feedback_msg.error_label2:
+                self.root.after(5000, lambda: self.clear_error_label())
+
             return True
 
         except Exception as e:
             print(f"Error updating {label} with \"{message}\": {e}")
             return False
+        
+    def clear_error_label(self):
+        # Clear the error label text
+        self.feedback_msg.error_label2.config(text = "")
         
     def appendNewUserInputHistory(self, message):
         # This function updates the user input history

--- a/source/ui/word/word_ui.py
+++ b/source/ui/word/word_ui.py
@@ -47,7 +47,7 @@ class WordWindow(tk.Tk):
 
             # If the label is the error label, schedule a function to clear it after 5000 milliseconds (5 seconds)
             if label == self.feedback_msg.error_label2:
-                self.root.after(5000, lambda: self.clear_error_label())
+                self.after(5000, lambda: self.clear_error_label())
 
             return True
 


### PR DESCRIPTION
- This functionality was added to the setLabel function
- If the error label is the label being set by the setLabel function, then:
- it runs the function: clearErrorLabel after a 5 second delay